### PR TITLE
resolve compilation error in snack bar component

### DIFF
--- a/app/src/main/java/com/example/tudee/presentation/components/SnackBarComponent.kt
+++ b/app/src/main/java/com/example/tudee/presentation/components/SnackBarComponent.kt
@@ -40,7 +40,7 @@ fun SnackBarComponent(
                 shape = RoundedCornerShape(16.dp),
                 spotColor = shadowColor
             )
-            .background(TudeeTheme.color.textColors.surfaceHigh, RoundedCornerShape(16.dp))
+            .background(TudeeTheme.color.surfaceHigh, RoundedCornerShape(16.dp))
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)


### PR DESCRIPTION
Due to the snack bar component not being up to date with the changes of `TudeeColors`, a compilation error occurred as a result.

By changing the use of `TudeeTheme.color.textColors.surfaceHigh` to `TudeeTheme.color.surfaceHigh`, the error is resolved.